### PR TITLE
Поправлен баг с висячей пустой страницей

### DIFF
--- a/src/components/Users.jsx
+++ b/src/components/Users.jsx
@@ -42,6 +42,10 @@ const Users = ({ allUsers, onDelete, onBookmark }) => {
     const usersCrop = paginate(filteredUsers, currentPage, PAGE_SIZE);
     const pagesCount = Math.ceil(filteredUsers.length / PAGE_SIZE);
 
+    if (pagesCount < currentPage && pagesCount > 0) {
+        setCurrentage((prevCurrentPage) => prevCurrentPage - 1);
+    }
+
     const usersList = usersCrop.map((user) => (
         <User
             key={user._id}


### PR DESCRIPTION
Выяснилось, что в алгоритме пагинации есть недостаток: при пересчёте количества страниц не меняется текущая страница. Из-за этого при удалении всех пользователей с последней страницы мы по-прежнему находимся на странице n, в то время как количество страниц уже давно стало n-1.